### PR TITLE
made python path/env more robust

### DIFF
--- a/cl_meats/cl_meats.py
+++ b/cl_meats/cl_meats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from socketIO_client import SocketIO
 import re, os, sys


### PR DESCRIPTION
![problem](https://f.cloud.github.com/assets/1972459/1629053/8789265e-5729-11e3-8f68-2bed16c7adc9.jpg)

This problem occurs when a user installs the dependencies to their usr/bin/local/python and the cl-meats client to a system level Library directory. The fix allows the program to run using the current user's environment defined version of python and it's installed modules.
